### PR TITLE
Uses ping to test connection to postgres

### DIFF
--- a/cmd/check/postgres.go
+++ b/cmd/check/postgres.go
@@ -16,6 +16,7 @@ limitations under the License.
 package check
 
 import (
+	"context"
 	"log"
 	"os"
 	"time"
@@ -67,9 +68,10 @@ func postgresCheck() {
 				Password: password,
 				Database: database,
 			})
-			_, err := pgdb.Exec("SELECT 1")
 
-			if err != nil {
+			ctx := context.Background()
+
+			if err := pgdb.Ping(ctx); err != nil {
 				log.Println(err)
 				exitCode = 1
 			} else {


### PR DESCRIPTION
Alteração conforme informações do FAQ da lib utilizada para conexão com o postgres.
https://pg.uptrace.dev/faq/#how-to-check-connection-health